### PR TITLE
Fix/get cache run add assoc

### DIFF
--- a/larpmanager/utils/event.py
+++ b/larpmanager/utils/event.py
@@ -131,7 +131,7 @@ def get_event_run(request, s, n, signup=False, slug=None, status=False):
 
 def get_run(ctx, s, n):
     try:
-        res = get_cache_run(s, n)
+        res = get_cache_run(ctx["a_id"], s, n)
         que = Run.objects.select_related("event")
         fields = [
             "search",

--- a/larpmanager/views/orga/event.py
+++ b/larpmanager/views/orga/event.py
@@ -69,7 +69,8 @@ def orga_appearance(request, s, n):
 
 @login_required
 def orga_run(request, s, n):
-    return orga_edit(request, s, n, "orga_run", OrgaRunForm, get_cache_run(s, n), "manage")
+    run = get_cache_run(request.assoc["id"], s, n)
+    return orga_edit(request, s, n, "orga_run", OrgaRunForm, run, "manage")
 
 
 @login_required

--- a/larpmanager/views/orga/registration.py
+++ b/larpmanager/views/orga/registration.py
@@ -729,7 +729,7 @@ def orga_pre_registrations(request, s, n):
 def orga_reload_cache(request, s, n):
     ctx = check_event_permission(request, s, n)
     reset_run(ctx["run"])
-    reset_cache_run(ctx["event"].slug, ctx["run"].number)
+    reset_cache_run(ctx["event"].assoc_id, ctx["event"].slug, ctx["run"].number)
     reset_event_features(ctx["event"].id)
     reset_run_event_links(ctx["event"])
     reset_cache_reg_counts(ctx["run"])

--- a/main/settings/__init__.py
+++ b/main/settings/__init__.py
@@ -5,15 +5,18 @@ RUNNING_PYTEST = 'pytest' in sys.modules or any('pytest' in arg for arg in sys.a
 
 if os.getenv('CI') == 'true' or os.getenv('GITHUB_ACTIONS') == 'true':
     from .ci import *
+    print("### SETTINGS ci")
 elif RUNNING_PYTEST:
     from .test import *
+    print("### SETTINGS test")
 else:
-    # you need to set "myproject = 'prod'" as an environment variable
-    # in your OS (on which your website is hosted)
     if 'env' in os.environ:
         if os.environ['env'] == 'prod':
+            print("### SETTINGS prod")
             from .prod import *
         elif os.environ['env'] == 'staging':
+            print("### SETTINGS staging")
             from .staging import *
     else:
         from .dev import *
+        print("### SETTINGS dev")


### PR DESCRIPTION
In `get_cache_run`, the parameter with assoc_id has been added (to avoid confusion of two events of different assocs with same slug) 
