### PR TITLE
Modified redirect after login

### DIFF
--- a/larpmanager/cache/login.py
+++ b/larpmanager/cache/login.py
@@ -1,0 +1,55 @@
+# LarpManager - https://larpmanager.com
+# Copyright (C) 2025 Scanagatta Mauro
+#
+# This file is part of LarpManager and is dual-licensed:
+#
+# 1. Under the terms of the GNU Affero General Public License (AGPL) version 3,
+#    as published by the Free Software Foundation. You may use, modify, and
+#    distribute this file under those terms.
+#
+# 2. Under a commercial license, allowing use in closed-source or proprietary
+#    environments without the obligations of the AGPL.
+#
+# If you have obtained this file under the AGPL, and you make it available over
+# a network, you must also make the complete source code available under the same license.
+#
+# For more information or to purchase a commercial license, contact:
+# commercial@larpmanager.com
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later OR Proprietary
+
+from django.core.cache import cache
+
+
+def get_session_key(request):
+    session_id = request.session.session_key
+    if not session_id:
+        request.session.save()
+        session_id = request.session.session_key
+    return f"login_{session_id}"
+
+
+def set_login_subdomain(request):
+    key = get_session_key(request)
+    subdomain = get_subdomain(request)
+    cache.set(key, subdomain, 600)
+
+
+def get_login_subdomain(request):
+    key = get_session_key(request)
+    return cache.get(key)
+
+
+def get_subdomain(request):
+    host = request.get_host()
+    host = host.split(":")[0]
+
+    parts = host.split(".")
+
+    domain_part_number = 2
+    if len(parts) > domain_part_number:
+        subdomain = parts[0]
+    else:
+        subdomain = None
+
+    return subdomain

--- a/larpmanager/templates/registration/login.html
+++ b/larpmanager/templates/registration/login.html
@@ -9,18 +9,20 @@
     {% for el in socialaccount_providers %}
         {% with prov=el.name|lower %}
             <a href="{% provider_login_url prov %}">
-                <img src="{% static 'larpmanager/assets/' %}{{ prov }}_signin.png" />
+                <img src="{% static 'larpmanager/assets/' %}{{ prov }}_signin.png"
+                     alt="login image" />
             </a>
         {% endwith %}
     {% endfor %}
 {% endblock old %}
 {% block content %}
-    <div class='login'>
+    <div class="login">
         <br />
         {% if not request.staging and not request.development %}
             <div class="allauth_signin">
                 <a href="{% get_login_url 'google' %}">
-                    <img src="{% static 'larpmanager/assets/' %}google_signin.png" />
+                    <img src="{% static 'larpmanager/assets/' %}google_signin.png"
+                         alt="login image" />
                 </a>
             </div>
         {% endif %}
@@ -66,22 +68,18 @@ window.addEventListener('DOMContentLoaded', function() {
 
     {% if  assoc.id != 0 %}
 
-       $('.allauth_signin a').each(function(index) {
-            var href = $(this).attr('href');
-            console.log(href);
+        // Before sign up, save the domain where we are making the login, to perform redirect
+       $('.allauth_signin a').on('click', function(event) {
+            const link = this;
+            event.preventDefault();
 
-            var domain = 'https://{{ assoc.slug }}.larpmanager.com';
-
-            next = /next=/g
-            if (!href.match(next)) {
-                href += 'next=' + domain;
-            } else {
-                aux = href.split(next);
-                href = aux[0] + 'next=' + domain + aux[1];
-            }
-
-            href = 'https://larpmanager.com' + href;
-            $(this).attr('href', href);
+            $.ajax({
+                url: '{% url 'prepare_login' %}',
+                method: 'GET',
+                complete: function() {
+                    window.location = link.href;
+                }
+            });
         });
 
     {% endif %}

--- a/larpmanager/urls/user.py
+++ b/larpmanager/urls/user.py
@@ -714,4 +714,9 @@ urlpatterns = [
         views_auth.MyPasswordResetConfirmView.as_view(form_class=MyPasswordResetConfirmForm),
         name="password_reset_confirm",
     ),
+    path(
+        "login/prepare/",
+        views_base.prepare_login,
+        name="prepare_login",
+    ),
 ]

--- a/larpmanager/views/base.py
+++ b/larpmanager/views/base.py
@@ -21,6 +21,7 @@
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
 
+from larpmanager.cache.login import set_login_subdomain
 from larpmanager.cache.role import get_index_assoc_permissions
 from larpmanager.models.association import Association
 from larpmanager.utils.base import def_user_ctx
@@ -65,3 +66,8 @@ def error_404(request, exception):
 
 def error_500(request):
     return render(request, "500.html")
+
+
+# Save the domain before the login
+def prepare_login(request):
+    set_login_subdomain(request)

--- a/larpmanager/views/larpmanager.py
+++ b/larpmanager/views/larpmanager.py
@@ -37,6 +37,7 @@ from django_ratelimit.decorators import ratelimit
 
 from larpmanager.cache.feature import get_assoc_features, get_event_features
 from larpmanager.cache.larpmanager import get_cache_promoters
+from larpmanager.cache.login import get_login_subdomain
 from larpmanager.cache.role import has_assoc_permission, has_event_permission
 from larpmanager.forms.association import (
     FirstAssociationForm,
@@ -87,6 +88,10 @@ from larpmanager.utils.text import get_assoc_text
 
 
 def lm_home(request):
+    subdomain = get_login_subdomain(request)
+    if subdomain:
+        return redirect(f"https://{subdomain}.larpmanager.com")
+
     ctx = get_lm_assocs()
     ctx["index"] = True
     ctx["promoters"] = get_cache_promoters()

--- a/larpmanager/views/orga/character.py
+++ b/larpmanager/views/orga/character.py
@@ -243,9 +243,9 @@ def orga_character_form_email(request, s, n):
         char = ctx["chars"][ch_num]
         if el.option_id not in res:
             res[el.option_id] = {"emails": [], "names": []}
-        res[el.option_id]["emails"].append(char["name"])
+        res[el.option_id]["names"].append(char["name"])
         if char["player_id"]:
-            res[el.option_id]["names"].append(char["player"])
+            res[el.option_id]["emails"].append(char["player"])
 
     n_res = {}
     for opt_id, value in res.items():


### PR DESCRIPTION
Since django-allauth has removed the parameter next in the login request, let's do something on our end. 

- Before login with social provider of django-allauth, an ajax call save the subdomain of the request. 
- After login, if the subdomain of the request is in the cache, redirect the user there. 